### PR TITLE
Add MIT license file to the repo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) 2020 Jersey Junior Devs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "jersey-junior-dev",
   "version": "1.0.0",
   "private": true,
-  "homepage": ".",
+  "homepage": "https://juniordevs.je",
+  "license": "MIT",
   "dependencies": {
     "classnames": "2.2.6",
     "gh-pages": "^2.1.1",


### PR DESCRIPTION
In order to ensure we can all safely edit this file and keep legal it's important that we define a license for the project.

As this is a community effort and open source project I believe MIT license will suit our needs. Happy to discuss it though if anyone believes that's not the case.